### PR TITLE
fix: bbox validation against tile grid

### DIFF
--- a/src/tiles.ts
+++ b/src/tiles.ts
@@ -1,7 +1,7 @@
 import { SCALE_FACTOR, TILEGRID_WORLD_CRS84 } from './constants';
 import { BoundingBox, LonLat, Tile, TileGrid } from './interfaces';
 import { Limits, Zoom } from './types';
-import { validateBoundingBox, validateLonlat, validateMetatile, validateTile, validateTileGrid, validateZoomLevel } from './validations';
+import { validateLonlat, validateMetatile, validateTile, validateTileGrid, validateTileGridBoundingBox, validateZoomLevel } from './validations';
 
 function clamp(value: number, minValue: number, maxValue: number): number {
   if (value < minValue) {
@@ -40,9 +40,9 @@ export function boundingBoxToTiles(
   metatile = 1,
   referenceTileGrid: TileGrid = TILEGRID_WORLD_CRS84
 ): Generator<Tile, undefined, undefined> {
-  validateBoundingBox(bbox);
   validateMetatile(metatile);
   validateTileGrid(referenceTileGrid);
+  validateTileGridBoundingBox(bbox, referenceTileGrid);
   validateZoomLevel(zoom, referenceTileGrid);
 
   const upperLeftTile = lonLatZoomToTile({ lon: bbox.west, lat: bbox.north }, zoom, metatile, referenceTileGrid);

--- a/src/validations.ts
+++ b/src/validations.ts
@@ -46,6 +46,26 @@ export function validateBoundingBox(bbox: BoundingBox): void {
   }
 }
 
+export function validateTileGridBoundingBox(bbox: BoundingBox, referenceTileGrid: TileGrid): void {
+  validateBoundingBox(bbox);
+
+  if (bbox.west < referenceTileGrid.boundingBox.west) {
+    throw new RangeError("bounding box's west must be larger or equal than the west value of tile grid's bounding box");
+  }
+
+  if (bbox.east > referenceTileGrid.boundingBox.east) {
+    throw new RangeError("bounding box's east must be smaller or equal than the east value of tile grid's bounding box");
+  }
+
+  if (bbox.south < referenceTileGrid.boundingBox.south) {
+    throw new RangeError("bounding box's south must be larger or equal than the south value of tile grid's bounding box");
+  }
+
+  if (bbox.north > referenceTileGrid.boundingBox.north) {
+    throw new RangeError("bounding box's north must be smaller or equal than the north value of tile grid's bounding box");
+  }
+}
+
 export function validateLonlat(lonlat: LonLat, referenceTileGrid: TileGrid): void {
   if (lonlat.lon < referenceTileGrid.boundingBox.west || lonlat.lon > referenceTileGrid.boundingBox.east) {
     throw new RangeError("longtitude out of range of tile grid's bounding box");

--- a/src/validations.ts
+++ b/src/validations.ts
@@ -49,30 +49,17 @@ export function validateBoundingBox(bbox: BoundingBox): void {
 export function validateTileGridBoundingBox(bbox: BoundingBox, referenceTileGrid: TileGrid): void {
   validateBoundingBox(bbox);
 
-  if (bbox.west < referenceTileGrid.boundingBox.west) {
-    throw new RangeError("bounding box's west must be larger or equal than the west value of tile grid's bounding box");
-  }
-
-  if (bbox.east > referenceTileGrid.boundingBox.east) {
-    throw new RangeError("bounding box's east must be smaller or equal than the east value of tile grid's bounding box");
-  }
-
-  if (bbox.south < referenceTileGrid.boundingBox.south) {
-    throw new RangeError("bounding box's south must be larger or equal than the south value of tile grid's bounding box");
-  }
-
-  if (bbox.north > referenceTileGrid.boundingBox.north) {
-    throw new RangeError("bounding box's north must be smaller or equal than the north value of tile grid's bounding box");
-  }
+  validateLonlat({ lon: bbox.west, lat: bbox.south }, referenceTileGrid);
+  validateLonlat({ lon: bbox.east, lat: bbox.north }, referenceTileGrid);
 }
 
 export function validateLonlat(lonlat: LonLat, referenceTileGrid: TileGrid): void {
   if (lonlat.lon < referenceTileGrid.boundingBox.west || lonlat.lon > referenceTileGrid.boundingBox.east) {
-    throw new RangeError("longtitude out of range of tile grid's bounding box");
+    throw new RangeError(`longtitude ${lonlat.lon} is out of range of tile grid's bounding box`);
   }
 
   if (lonlat.lat < referenceTileGrid.boundingBox.south || lonlat.lat > referenceTileGrid.boundingBox.north) {
-    throw new RangeError("latitude out of range of tile grid's bounding box");
+    throw new RangeError(`latitude ${lonlat.lat} is out of range of tile grid's bounding box`);
   }
 }
 

--- a/tests/unit/tiles.spec.ts
+++ b/tests/unit/tiles.spec.ts
@@ -91,7 +91,7 @@ describe('#boundingBoxToTiles', () => {
       boundingBoxToTiles(bbox, zoom);
     };
 
-    expect(badTilesGenerator).toThrow(RangeError("bounding box's west must be larger or equal than the west value of tile grid's bounding box"));
+    expect(badTilesGenerator).toThrow(RangeError("longtitude -190 is out of range of tile grid's bounding box"));
   });
   it("should throw an error when the given bounding box's east value is larger than tile grid's bounding box east value", () => {
     const bbox: BoundingBox = { west: 30, south: -30, east: 190, north: 30 };
@@ -101,7 +101,7 @@ describe('#boundingBoxToTiles', () => {
       boundingBoxToTiles(bbox, zoom);
     };
 
-    expect(badTilesGenerator).toThrow(RangeError("bounding box's east must be smaller or equal than the east value of tile grid's bounding box"));
+    expect(badTilesGenerator).toThrow(RangeError("longtitude 190 is out of range of tile grid's bounding box"));
   });
   it("should throw an error when the given bounding box's south value is less than tile grid's bounding box south value", () => {
     const bbox: BoundingBox = { west: 30, south: -100, east: 40, north: 30 };
@@ -111,7 +111,7 @@ describe('#boundingBoxToTiles', () => {
       boundingBoxToTiles(bbox, zoom);
     };
 
-    expect(badTilesGenerator).toThrow(RangeError("bounding box's south must be larger or equal than the south value of tile grid's bounding box"));
+    expect(badTilesGenerator).toThrow(RangeError("latitude -100 is out of range of tile grid's bounding box"));
   });
   it("should throw an error when the given bounding box's north value is larger than tile grid's bounding box north value", () => {
     const bbox: BoundingBox = { west: 30, south: -30, east: 40, north: 100 };
@@ -121,7 +121,7 @@ describe('#boundingBoxToTiles', () => {
       boundingBoxToTiles(bbox, zoom);
     };
 
-    expect(badTilesGenerator).toThrow(RangeError("bounding box's north must be smaller or equal than the north value of tile grid's bounding box"));
+    expect(badTilesGenerator).toThrow(RangeError("latitude 100 is out of range of tile grid's bounding box"));
   });
 });
 
@@ -233,7 +233,7 @@ describe('#lonLatZoomToTile', () => {
       lonLatZoomToTile(lonLat, zoom);
     };
 
-    expect(badLonLatZoomToTile).toThrow(RangeError("longtitude out of range of tile grid's bounding box"));
+    expect(badLonLatZoomToTile).toThrow(RangeError("longtitude -190 is out of range of tile grid's bounding box"));
   });
   it("should throw an error when latitude is outside of tile grid's bounding box", () => {
     const lonLat: LonLat = { lon: 30, lat: 100 };
@@ -243,7 +243,7 @@ describe('#lonLatZoomToTile', () => {
       lonLatZoomToTile(lonLat, zoom);
     };
 
-    expect(badLonLatZoomToTile).toThrow(RangeError("latitude out of range of tile grid's bounding box"));
+    expect(badLonLatZoomToTile).toThrow(RangeError("latitude 100 is out of range of tile grid's bounding box"));
   });
   it("should throw an error when the zoom level is not part of zoom levels of tile grid's scale set", () => {
     const lonLat: LonLat = { lon: 30, lat: 30 };

--- a/tests/unit/tiles.spec.ts
+++ b/tests/unit/tiles.spec.ts
@@ -83,6 +83,46 @@ describe('#boundingBoxToTiles', () => {
 
     expect(badTilesGenerator).toThrow(Error("bounding box's north must be larger than south"));
   });
+  it("should throw an error when the given bounding box's west value is less than tile grid's bounding box west value", () => {
+    const bbox: BoundingBox = { west: -190, south: -30, east: 40, north: 30 };
+    const zoom: Zoom = 3;
+
+    const badTilesGenerator = (): void => {
+      boundingBoxToTiles(bbox, zoom);
+    };
+
+    expect(badTilesGenerator).toThrow(Error("bounding box's west must be larger or equal than the west value of tile grid's bounding box"));
+  });
+  it("should throw an error when the given bounding box's east value is larger than tile grid's bounding box east value", () => {
+    const bbox: BoundingBox = { west: 30, south: -30, east: 190, north: 30 };
+    const zoom: Zoom = 3;
+
+    const badTilesGenerator = (): void => {
+      boundingBoxToTiles(bbox, zoom);
+    };
+
+    expect(badTilesGenerator).toThrow(Error("bounding box's east must be smaller or equal than the east value of tile grid's bounding box"));
+  });
+  it("should throw an error when the given bounding box's south value is less than tile grid's bounding box south value", () => {
+    const bbox: BoundingBox = { west: 30, south: -100, east: 40, north: 30 };
+    const zoom: Zoom = 3;
+
+    const badTilesGenerator = (): void => {
+      boundingBoxToTiles(bbox, zoom);
+    };
+
+    expect(badTilesGenerator).toThrow(Error("bounding box's south must be larger or equal than the south value of tile grid's bounding box"));
+  });
+  it("should throw an error when the given bounding box's north value is larger than tile grid's bounding box north value", () => {
+    const bbox: BoundingBox = { west: 30, south: -30, east: 40, north: 100 };
+    const zoom: Zoom = 3;
+
+    const badTilesGenerator = (): void => {
+      boundingBoxToTiles(bbox, zoom);
+    };
+
+    expect(badTilesGenerator).toThrow(Error("bounding box's north must be smaller or equal than the north value of tile grid's bounding box"));
+  });
 });
 
 describe('#zoomShift', () => {

--- a/tests/unit/tiles.spec.ts
+++ b/tests/unit/tiles.spec.ts
@@ -91,7 +91,7 @@ describe('#boundingBoxToTiles', () => {
       boundingBoxToTiles(bbox, zoom);
     };
 
-    expect(badTilesGenerator).toThrow(Error("bounding box's west must be larger or equal than the west value of tile grid's bounding box"));
+    expect(badTilesGenerator).toThrow(RangeError("bounding box's west must be larger or equal than the west value of tile grid's bounding box"));
   });
   it("should throw an error when the given bounding box's east value is larger than tile grid's bounding box east value", () => {
     const bbox: BoundingBox = { west: 30, south: -30, east: 190, north: 30 };
@@ -101,7 +101,7 @@ describe('#boundingBoxToTiles', () => {
       boundingBoxToTiles(bbox, zoom);
     };
 
-    expect(badTilesGenerator).toThrow(Error("bounding box's east must be smaller or equal than the east value of tile grid's bounding box"));
+    expect(badTilesGenerator).toThrow(RangeError("bounding box's east must be smaller or equal than the east value of tile grid's bounding box"));
   });
   it("should throw an error when the given bounding box's south value is less than tile grid's bounding box south value", () => {
     const bbox: BoundingBox = { west: 30, south: -100, east: 40, north: 30 };
@@ -111,7 +111,7 @@ describe('#boundingBoxToTiles', () => {
       boundingBoxToTiles(bbox, zoom);
     };
 
-    expect(badTilesGenerator).toThrow(Error("bounding box's south must be larger or equal than the south value of tile grid's bounding box"));
+    expect(badTilesGenerator).toThrow(RangeError("bounding box's south must be larger or equal than the south value of tile grid's bounding box"));
   });
   it("should throw an error when the given bounding box's north value is larger than tile grid's bounding box north value", () => {
     const bbox: BoundingBox = { west: 30, south: -30, east: 40, north: 100 };
@@ -121,7 +121,7 @@ describe('#boundingBoxToTiles', () => {
       boundingBoxToTiles(bbox, zoom);
     };
 
-    expect(badTilesGenerator).toThrow(Error("bounding box's north must be smaller or equal than the north value of tile grid's bounding box"));
+    expect(badTilesGenerator).toThrow(RangeError("bounding box's north must be smaller or equal than the north value of tile grid's bounding box"));
   });
 });
 


### PR DESCRIPTION
When `boundingBoxToTiles` was called it didn't validate the `bbox` against `referenceTileGrid`'s bbox.
Added a validation of a bounding box against a bounding box of a tile grid

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✖                                                                       |