### PR TITLE
fix: tile's metatile should be used if available

### DIFF
--- a/src/tiles.ts
+++ b/src/tiles.ts
@@ -99,11 +99,10 @@ export function lonLatZoomToTile(lonlat: LonLat, zoom: Zoom, metatile = 1, refer
   };
 }
 
-export function tileToBoundingBox(tile: Tile, metatile = 1, referenceTileGrid: TileGrid = TILEGRID_WORLD_CRS84): BoundingBox {
-  validateMetatile(metatile);
+export function tileToBoundingBox(tile: Tile, referenceTileGrid: TileGrid = TILEGRID_WORLD_CRS84): BoundingBox {
   validateTileGrid(referenceTileGrid);
-  metatile = tile.metatile ?? metatile;
-  validateTile(tile, metatile, referenceTileGrid);
+  validateTile(tile, referenceTileGrid);
+  const metatile = tile.metatile ?? 1;
 
   const width = tileWidth(tile.z, referenceTileGrid) * metatile;
   const height = tileHeight(tile.z, referenceTileGrid) * metatile;

--- a/src/tiles.ts
+++ b/src/tiles.ts
@@ -102,6 +102,7 @@ export function lonLatZoomToTile(lonlat: LonLat, zoom: Zoom, metatile = 1, refer
 export function tileToBoundingBox(tile: Tile, metatile = 1, referenceTileGrid: TileGrid = TILEGRID_WORLD_CRS84): BoundingBox {
   validateMetatile(metatile);
   validateTileGrid(referenceTileGrid);
+  metatile = tile.metatile ?? metatile;
   validateTile(tile, metatile, referenceTileGrid);
 
   const width = tileWidth(tile.z, referenceTileGrid) * metatile;

--- a/src/validations.ts
+++ b/src/validations.ts
@@ -62,14 +62,17 @@ export function validateZoomLevel(zoom: Zoom, referenceTileGrid: TileGrid): void
   }
 }
 
-export function validateTile(tile: Tile, metatile: number, referenceTileGrid: TileGrid): void {
+export function validateTile(tile: Tile, referenceTileGrid: TileGrid): void {
   validateZoomLevel(tile.z, referenceTileGrid);
+  if (tile.metatile !== undefined) {
+    validateMetatile(tile.metatile);
+  }
 
-  if (tile.x < 0 || tile.x >= (referenceTileGrid.numberOfMinLevelTilesX / metatile) * SCALE_FACTOR ** tile.z) {
+  if (tile.x < 0 || tile.x >= (referenceTileGrid.numberOfMinLevelTilesX / (tile.metatile ?? 1)) * SCALE_FACTOR ** tile.z) {
     throw new RangeError('x index out of range of tile grid');
   }
 
-  if (tile.y < 0 || tile.y >= (referenceTileGrid.numberOfMinLevelTilesY / metatile) * SCALE_FACTOR ** tile.z) {
+  if (tile.y < 0 || tile.y >= (referenceTileGrid.numberOfMinLevelTilesY / (tile.metatile ?? 1)) * SCALE_FACTOR ** tile.z) {
     throw new RangeError('y index out of range of tile grid');
   }
 }

--- a/tests/unit/tiles.spec.ts
+++ b/tests/unit/tiles.spec.ts
@@ -237,6 +237,14 @@ describe('#tileToBoundingBox', () => {
 
     expect(boundingBox).toEqual(expected);
   });
+  it('should return a bounding box for a given tile which contains a metatile size that overrides the default', () => {
+    const tile: Tile = { x: 1, y: 0, z: 1, metatile: 2 };
+    const expected: BoundingBox = { west: 0, south: -90, east: 180, north: 90 };
+
+    const boundingBox = tileToBoundingBox(tile);
+
+    expect(boundingBox).toEqual(expected);
+  });
   it('should return a bounding box for a given tile with non default metatile', () => {
     const tile: Tile = { x: 1, y: 0, z: 1 };
     const metatile = 2;

--- a/tests/unit/tiles.spec.ts
+++ b/tests/unit/tiles.spec.ts
@@ -245,15 +245,6 @@ describe('#tileToBoundingBox', () => {
 
     expect(boundingBox).toEqual(expected);
   });
-  it('should return a bounding box for a given tile with non default metatile', () => {
-    const tile: Tile = { x: 1, y: 0, z: 1 };
-    const metatile = 2;
-    const expected: BoundingBox = { west: 0, south: -90, east: 180, north: 90 };
-
-    const boundingBox = tileToBoundingBox(tile, metatile);
-
-    expect(boundingBox).toEqual(expected);
-  });
   it('should return a bounding box for a given tile with non default tile grid', () => {
     const tile: Tile = { x: 0, y: 0, z: 0 };
     const tileGrid: TileGrid = TILEGRID_WEB_MERCATOR;
@@ -264,14 +255,13 @@ describe('#tileToBoundingBox', () => {
       north: TILEGRID_WEB_MERCATOR.boundingBox.north,
     };
 
-    const boundingBox = tileToBoundingBox(tile, undefined, tileGrid);
+    const boundingBox = tileToBoundingBox(tile, tileGrid);
 
     expect(boundingBox).toEqual(expected);
   });
   it('should return a bounding box for a given tile with non default tile grid & non default metatile', () => {
-    const tile: Tile = { x: 1, y: 0, z: 2 };
+    const tile: Tile = { x: 1, y: 0, z: 2, metatile: 3 };
     const tileGrid: TileGrid = TILEGRID_WEB_MERCATOR;
-    const metatile = 3;
     const expected: BoundingBox = {
       west: 90,
       south: -42.525564389903295,
@@ -279,7 +269,7 @@ describe('#tileToBoundingBox', () => {
       north: 85.05112877980659,
     };
 
-    const boundingBox = tileToBoundingBox(tile, metatile, tileGrid);
+    const boundingBox = tileToBoundingBox(tile, tileGrid);
 
     expect(boundingBox).toEqual(expected);
   });
@@ -311,31 +301,28 @@ describe('#tileToBoundingBox', () => {
     expect(badTileToBoundingBox).toThrow(Error('zoom level is not part of the given well known scale set'));
   });
   it("should throw an error when the tile's x index is outside of tile grid because of large enough metatile", () => {
-    const tile: Tile = { x: 1, y: 0, z: 0 };
-    const metatile = 2;
+    const tile: Tile = { x: 1, y: 0, z: 0, metatile: 2 };
 
     const badTileToBoundingBox = (): void => {
-      tileToBoundingBox(tile, metatile);
+      tileToBoundingBox(tile);
     };
 
     expect(badTileToBoundingBox).toThrow(RangeError('x index out of range of tile grid'));
   });
   it("should throw an error when the tile's y index is outside of tile grid because of large enough metatile", () => {
-    const tile: Tile = { x: 0, y: 1, z: 0 };
-    const metatile = 2;
+    const tile: Tile = { x: 0, y: 1, z: 0, metatile: 2 };
 
     const badTileToBoundingBox = (): void => {
-      tileToBoundingBox(tile, metatile);
+      tileToBoundingBox(tile);
     };
 
     expect(badTileToBoundingBox).toThrow(RangeError('y index out of range of tile grid'));
   });
   it('should throw an error when metatile is zero or less', () => {
-    const tile: Tile = { x: 0, y: 0, z: 0 };
-    const metatile = 0;
+    const tile: Tile = { x: 0, y: 0, z: 0, metatile: 0 };
 
     const badTileToBoundingBox = (): void => {
-      tileToBoundingBox(tile, metatile);
+      tileToBoundingBox(tile);
     };
 
     expect(badTileToBoundingBox).toThrow(new Error('metatile must be larger than 0'));
@@ -413,7 +400,7 @@ describe('#tileToBoundingBox', () => {
     },
   ])("should throw an error when the tile grid's $testCaseName", ({ tile, tileGrid, expected }) => {
     const badTileToBoundingBox = (): void => {
-      tileToBoundingBox(tile, undefined, tileGrid);
+      tileToBoundingBox(tile, tileGrid);
     };
 
     expect(badTileToBoundingBox).toThrow(new Error(expected));


### PR DESCRIPTION
Currently `tileToBoundingBox` ignores the tile's metatile field. Now, this field will be preferred over the metatile passed directly to `tileToBoundingBox`

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✖                                                                       |